### PR TITLE
Improve relative paths and add mobile input

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <title>New Tetris</title>
-    <link rel="stylesheet" href="/styles.css">
+    <link rel="stylesheet" href="styles.css">
   </head>
   <body>
     <main class="wrap">
@@ -12,6 +12,16 @@
       <canvas id="game" width="240" height="480"></canvas>
       <p class="hint">← → to move • ↑ rotate • ↓ soft drop • Space hard drop</p>
     </main>
-    <script type="module" src="/src/main.js"></script>
+
+    <!-- Mobile controls -->
+    <div id="touch" style="position:fixed;left:0;right:0;bottom:10px;display:flex;gap:10px;justify-content:center">
+      <button data-act="left">◀︎</button>
+      <button data-act="rotate">⟲</button>
+      <button data-act="drop">▼</button>
+      <button data-act="right">▶︎</button>
+      <button data-act="hard">⤓</button>
+    </div>
+
+    <script type="module" src="src/main.js"></script>
   </body>
 </html>

--- a/src/input.js
+++ b/src/input.js
@@ -7,4 +7,17 @@ export function attachInput(game){
     if(e.key === 'ArrowDown') game.softDrop()
     if(e.code === 'Space') game.hardDrop()
   })
+
+  const touch = document.getElementById('touch')
+  if (touch){
+    touch.addEventListener('click', (e)=>{
+      const act = e.target?.dataset?.act
+      if(!act) return
+      if(act==='left') game.move(-1)
+      if(act==='right') game.move(1)
+      if(act==='rotate') game.rotate(1)
+      if(act==='drop') game.softDrop()
+      if(act==='hard') game.hardDrop()
+    })
+  }
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,4 +1,6 @@
 import { defineConfig } from 'vite'
+
 export default defineConfig({
-  base: '/REPO_NAME_HERE/'
+  // Use relative paths so it works both on username.github.io and username.github.io/repo
+  base: './'
 })


### PR DESCRIPTION
## Summary
- Use relative base path for Vite build to support root and repo deployments
- Add mobile touch controls to the page and input handler

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb9f66a5c88330a298e82283a96a38