### PR TITLE
feat: add mobile-friendly controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,16 +10,14 @@
     <main class="wrap">
       <h1>New Tetris</h1>
       <canvas id="game" width="240" height="480"></canvas>
-      <p class="hint">← → to move • ↑ rotate • ↓ soft drop • Space hard drop</p>
     </main>
 
-    <!-- Mobile controls -->
-    <div id="touch" style="position:fixed;left:0;right:0;bottom:10px;display:flex;gap:10px;justify-content:center">
-      <button data-act="left">◀︎</button>
-      <button data-act="rotate">⟲</button>
-      <button data-act="drop">▼</button>
-      <button data-act="right">▶︎</button>
-      <button data-act="hard">⤓</button>
+    <div id="controls" class="controls" role="group" aria-label="Game controls">
+      <button id="btn-left"   class="ctrl" data-key="ArrowLeft"  aria-label="Move left">⬅️<span class="label">Left</span></button>
+      <button id="btn-rotate" class="ctrl" data-key="ArrowUp"    aria-label="Rotate">🔄<span class="label">Rotate</span></button>
+      <button id="btn-right"  class="ctrl" data-key="ArrowRight" aria-label="Move right">➡️<span class="label">Right</span></button>
+      <button id="btn-soft"   class="ctrl" data-key="ArrowDown"  aria-label="Soft drop">⬇️<span class="label">Soft</span></button>
+      <button id="btn-hard"   class="ctrl" data-key=" "          aria-label="Hard drop">⏬<span class="label">Hard</span></button>
     </div>
 
     <script type="module" src="src/main.js"></script>

--- a/src/input.js
+++ b/src/input.js
@@ -5,19 +5,19 @@ export function attachInput(game){
     if(e.key === 'ArrowRight') game.move(1)
     if(e.key === 'ArrowUp') game.rotate(1)
     if(e.key === 'ArrowDown') game.softDrop()
-    if(e.code === 'Space') game.hardDrop()
+    if(e.code === 'Space' || e.key === ' ') game.hardDrop()
   })
 
-  const touch = document.getElementById('touch')
-  if (touch){
-    touch.addEventListener('click', (e)=>{
-      const act = e.target?.dataset?.act
-      if(!act) return
-      if(act==='left') game.move(-1)
-      if(act==='right') game.move(1)
-      if(act==='rotate') game.rotate(1)
-      if(act==='drop') game.softDrop()
-      if(act==='hard') game.hardDrop()
-    })
+  function triggerKey(key) {
+    const ev = new KeyboardEvent('keydown', { key })
+    document.dispatchEvent(ev)
+    window.dispatchEvent(ev)
   }
+
+  document.querySelectorAll('.controls .ctrl').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const key = btn.getAttribute('data-key')
+      triggerKey(key)
+    }, { passive: true })
+  })
 }

--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,55 @@
 html,body{height:100%;margin:0;font-family:system-ui,Segoe UI,Roboto,Helvetica,Arial,sans-serif}
 .wrap{min-height:100%;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:12px}
 #game{image-rendering:pixelated;border:1px solid #ccc;box-shadow:0 8px 24px rgba(0,0,0,.1);background:#111}
+
+.controls {
+  position: sticky;
+  bottom: 0;
+  z-index: 10;
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+  padding: 12px 16px calc(12px + env(safe-area-inset-bottom));
+  background: #ffffff;
+  box-shadow: 0 -6px 20px rgba(0,0,0,0.08);
+}
+
+.ctrl {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  min-width: 72px;
+  min-height: 72px;
+  padding: 10px 12px;
+  font-size: clamp(18px, 3.5vw, 22px);
+  line-height: 1;
+  border: none;
+  border-radius: 12px;
+  background: #111;
+  color: #ffd233;
+  box-shadow: 0 4px 10px rgba(0,0,0,0.2);
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+  user-select: none;
+  cursor: pointer;
+}
+
+.ctrl:active { transform: scale(0.98); }
+
+.ctrl .label {
+  font-size: 12px;
+  line-height: 1;
+  letter-spacing: 0.2px;
+}
+
+@media (max-width: 420px) {
+  .ctrl { min-width: 64px; min-height: 64px; }
+  .ctrl .label { font-size: 11px; }
+}
+
+/* Give the play area breathing room so controls don't overlap it */
+.wrap, canvas, #gameRoot {
+  padding-bottom: 110px;
+}


### PR DESCRIPTION
## Summary
- redesign bottom controls with accessible icons and labels
- remove old instruction text and touch controls
- trigger keyboard events from tap-friendly buttons

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bbab20495c833085a226b354f95060