### PR TITLE
Add icon-based on-screen controls with dark theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,11 +13,21 @@
     </main>
 
     <div id="controls" class="controls" role="group" aria-label="Game controls">
-      <button id="btn-left"   class="ctrl" data-key="ArrowLeft"  aria-label="Move left">⬅️<span class="label">Left</span></button>
-      <button id="btn-rotate" class="ctrl" data-key="ArrowUp"    aria-label="Rotate">🔄<span class="label">Rotate</span></button>
-      <button id="btn-right"  class="ctrl" data-key="ArrowRight" aria-label="Move right">➡️<span class="label">Right</span></button>
-      <button id="btn-soft"   class="ctrl" data-key="ArrowDown"  aria-label="Soft drop">⬇️<span class="label">Soft</span></button>
-      <button id="btn-hard"   class="ctrl" data-key=" "          aria-label="Hard drop">⏬<span class="label">Hard</span></button>
+      <button id="btn-left" class="ctrl" data-key="ArrowLeft" aria-label="Move left">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M15 18l-6-6 6-6v12z"/></svg>
+      </button>
+      <button id="btn-rotate" class="ctrl" data-key="ArrowUp" aria-label="Rotate">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 6V3L8 7l4 4V8c2.8 0 5 2.2 5 5 0 1.5-.7 2.8-1.8 3.7l1.5 1.5C16.5 16.8 17 15.5 17 14c0-3.3-2.7-6-6-6z"/></svg>
+      </button>
+      <button id="btn-right" class="ctrl" data-key="ArrowRight" aria-label="Move right">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M9 6l6 6-6 6V6z"/></svg>
+      </button>
+      <button id="btn-soft" class="ctrl" data-key="ArrowDown" aria-label="Soft drop">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M7 10l5 5 5-5H7z"/></svg>
+      </button>
+      <button id="btn-hard" class="ctrl" data-key=" " aria-label="Hard drop">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 21l-8-8h16l-8 8zM12 3v10"/></svg>
+      </button>
     </div>
 
     <script type="module" src="src/main.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -1,55 +1,67 @@
-html,body{height:100%;margin:0;font-family:system-ui,Segoe UI,Roboto,Helvetica,Arial,sans-serif}
-.wrap{min-height:100%;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:12px}
-#game{image-rendering:pixelated;border:1px solid #ccc;box-shadow:0 8px 24px rgba(0,0,0,.1);background:#111}
-
-.controls {
-  position: sticky;
-  bottom: 0;
-  z-index: 10;
-  display: flex;
-  justify-content: center;
-  gap: 12px;
-  padding: 12px 16px calc(12px + env(safe-area-inset-bottom));
-  background: #ffffff;
-  box-shadow: 0 -6px 20px rgba(0,0,0,0.08);
+html, body {
+  height: 100%;
+  margin: 0;
+  padding: 0;
 }
 
-.ctrl {
-  display: inline-flex;
+body {
+  background: #121212;
+  color: #fff;
+  font-family: 'Roboto', sans-serif;
+  display: flex;
   flex-direction: column;
   align-items: center;
+}
+
+h1 {
+  margin: 20px 0;
+  font-size: 2rem;
+  letter-spacing: 1px;
+  font-weight: 600;
+}
+
+#game {
+  background: #1e1e1e;
+  border: 2px solid #333;
+  box-shadow: 0 0 20px rgba(0,0,0,0.6);
+  border-radius: 12px;
+  margin: 10px 0 20px 0;
+  image-rendering: pixelated;
+}
+
+.controls {
+  display: flex;
   justify-content: center;
-  gap: 4px;
-  min-width: 72px;
-  min-height: 72px;
-  padding: 10px 12px;
-  font-size: clamp(18px, 3.5vw, 22px);
-  line-height: 1;
+  gap: 16px;
+  margin-bottom: 30px;
+}
+
+.controls .ctrl {
+  background: linear-gradient(145deg, #2d2d2d, #1a1a1a);
   border: none;
   border-radius: 12px;
-  background: #111;
-  color: #ffd233;
-  box-shadow: 0 4px 10px rgba(0,0,0,0.2);
-  touch-action: manipulation;
-  -webkit-tap-highlight-color: transparent;
-  user-select: none;
+  padding: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   cursor: pointer;
+  box-shadow: 0 4px 8px rgba(0,0,0,0.4);
+  transition: all 0.2s ease;
 }
 
-.ctrl:active { transform: scale(0.98); }
-
-.ctrl .label {
-  font-size: 12px;
-  line-height: 1;
-  letter-spacing: 0.2px;
+.controls .ctrl:hover {
+  background: linear-gradient(145deg, #3a3a3a, #222);
+  transform: translateY(-2px);
+  box-shadow: 0 6px 14px rgba(0,0,0,0.5);
 }
 
-@media (max-width: 420px) {
-  .ctrl { min-width: 64px; min-height: 64px; }
-  .ctrl .label { font-size: 11px; }
+.controls .ctrl:active {
+  transform: translateY(0);
+  box-shadow: 0 2px 6px rgba(0,0,0,0.4);
 }
 
-/* Give the play area breathing room so controls don't overlap it */
-.wrap, canvas, #gameRoot {
-  padding-bottom: 110px;
+.controls svg {
+  width: 28px;
+  height: 28px;
+  fill: #00ffc3;
 }


### PR DESCRIPTION
## Summary
- Replace text buttons with SVG icons for movement and drops
- Restyle layout with dark theme and gradient control buttons

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bbacb6a1cc83309e781e35fe321146