### PR TITLE
Add rotate icon and game over alert

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,9 @@
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M15 18l-6-6 6-6v12z"/></svg>
       </button>
       <button id="btn-rotate" class="ctrl" data-key="ArrowUp" aria-label="Rotate">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 6V3L8 7l4 4V8c2.8 0 5 2.2 5 5 0 1.5-.7 2.8-1.8 3.7l1.5 1.5C16.5 16.8 17 15.5 17 14c0-3.3-2.7-6-6-6z"/></svg>
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 24 24">
+          <path d="M12 6V3L8 7l4 4V8c2.76 0 5 2.24 5 5a5 5 0 0 1-9.9 1h-2.02A7 7 0 0 0 12 20a7 7 0 0 0 0-14z"/>
+        </svg>
       </button>
       <button id="btn-right" class="ctrl" data-key="ArrowRight" aria-label="Move right">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M9 6l6 6-6 6V6z"/></svg>

--- a/src/tetris.js
+++ b/src/tetris.js
@@ -66,6 +66,7 @@ export class Game{
   spawn(){
     this.active = this.randPiece()
     if(this.collide(this.active.matrix, this.active.pos)){
+      alert("You lost!")
       this.arena.forEach(r=>r.fill(0))
     }
   }


### PR DESCRIPTION
## Summary
- Replace rotate button icon with modern SVG and keep styling
- Alert player on game over to improve feedback

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bbaf13ea888330b24174adada8abd6