### PR TITLE
Add ghost-themed overlay and start button to Tetris

### DIFF
--- a/assets/ghost.svg
+++ b/assets/ghost.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#fffafc"/>
+      <stop offset="1" stop-color="#f3eaff"/>
+    </linearGradient>
+  </defs>
+  <g>
+    <path d="M32 6c-11 0-18 8-18 19v20c0 3 3 3 5 1s3-2 5 0 3 2 5 0 3-2 5 0 3 2 5 0 3-2 5 0 5 2 5-1V25C50 14 43 6 32 6z" fill="url(#g)" stroke="#9b8ff2" stroke-width="2" stroke-linejoin="round"/>
+    <circle cx="24" cy="26" r="4" fill="#4b3f96"/>
+    <circle cx="40" cy="26" r="4" fill="#4b3f96"/>
+    <circle cx="25" cy="25" r="1.5" fill="#fff"/>
+    <circle cx="41" cy="25" r="1.5" fill="#fff"/>
+    <path d="M24 36c2 2 6 2 8 0" stroke="#4b3f96" stroke-width="2" fill="none" stroke-linecap="round"/>
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -3,35 +3,48 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
-    <title>New Tetris</title>
+    <title>Ghostris</title>
     <link rel="stylesheet" href="styles.css">
   </head>
   <body>
-    <main class="wrap">
-      <h1>New Tetris</h1>
-      <canvas id="game" width="240" height="480"></canvas>
-    </main>
-
-    <div id="controls" class="controls" role="group" aria-label="Game controls">
-      <button id="btn-left" class="ctrl" data-key="ArrowLeft" aria-label="Move left">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M15 18l-6-6 6-6v12z"/></svg>
-      </button>
-      <button id="btn-rotate" class="ctrl" data-key="ArrowUp" aria-label="Rotate">
-        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 24 24">
-          <path d="M12 6V3L8 7l4 4V8c2.76 0 5 2.24 5 5a5 5 0 0 1-9.9 1h-2.02A7 7 0 0 0 12 20a7 7 0 0 0 0-14z"/>
-        </svg>
-      </button>
-      <button id="btn-right" class="ctrl" data-key="ArrowRight" aria-label="Move right">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M9 6l6 6-6 6V6z"/></svg>
-      </button>
-      <button id="btn-soft" class="ctrl" data-key="ArrowDown" aria-label="Soft drop">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M7 10l5 5 5-5H7z"/></svg>
-      </button>
-      <button id="btn-hard" class="ctrl" data-key=" " aria-label="Hard drop">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 21l-8-8h16l-8 8zM12 3v10"/></svg>
-      </button>
+    <!-- Start / Game Over Overlay -->
+    <div id="startScreen" class="overlay visible">
+      <div class="overlay-card">
+        <img src="assets/ghost.svg" alt="cute ghost" class="ghost-hero" />
+        <h1>Ghostris</h1>
+        <p>Stack the blocks. Keep the ghosts smiling 👻</p>
+        <button id="startBtn" class="btn primary">Start</button>
+      </div>
     </div>
 
-    <script type="module" src="src/main.js"></script>
+    <div id="game">
+      <main class="wrap">
+        <canvas id="board" width="240" height="480"></canvas>
+      </main>
+
+      <div id="controls" class="controls" role="group" aria-label="Game controls">
+        <button id="btn-left" class="btn ghost" data-key="ArrowLeft" aria-label="Move left">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M15 18l-6-6 6-6v12z"/></svg>
+        </button>
+        <button id="btn-rotate" class="btn ghost" data-key="ArrowUp" aria-label="Rotate">
+          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M12 6V3L8 7l4 4V8c2.76 0 5 2.24 5 5a5 5 0 0 1-9.9 1h-2.02A7 7 0 0 0 12 20a7 7 0 0 0 0-14z"/>
+          </svg>
+        </button>
+        <button id="btn-right" class="btn ghost" data-key="ArrowRight" aria-label="Move right">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M9 6l6 6-6 6V6z"/></svg>
+        </button>
+        <button id="btn-soft" class="btn ghost" data-key="ArrowDown" aria-label="Soft drop">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M7 10l5 5 5-5H7z"/></svg>
+        </button>
+        <button id="btn-hard" class="btn ghost" data-key=" " aria-label="Hard drop">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 21l-8-8h16l-8 8zM12 3v10"/></svg>
+        </button>
+      </div>
+    </div>
+
+    <footer class="credit"><small>Ghost theme by ChatGPT</small></footer>
+
+    <script type="module" src="script.js"></script>
   </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,95 @@
+import { Game } from './src/tetris.js';
+import { attachInput } from './src/input.js';
+
+const canvas = document.getElementById('board');
+const ctx = canvas.getContext('2d');
+const game = new Game(10, 20);
+attachInput(game);
+
+const ghostImg = new Image();
+ghostImg.src = 'assets/ghost.svg';
+
+// --- Start gate / overlay wiring ---
+let gameStarted = false;
+const overlay = document.getElementById('startScreen');
+const startBtn = document.getElementById('startBtn');
+
+function showOverlay(label = 'Start'){
+  if (startBtn) startBtn.textContent = label;
+  overlay?.classList.add('visible');
+}
+function hideOverlay(){
+  overlay?.classList.remove('visible');
+}
+
+startBtn?.addEventListener('click', () => {
+  if (!gameStarted) {
+    gameStarted = true;
+    resetGame();
+    hideOverlay();
+    startGameLoop();
+  } else {
+    resetGame();
+    hideOverlay();
+    startGameLoop();
+  }
+});
+
+// Call once on load to show start screen
+showOverlay('Start');
+
+// --- Game loop ---
+let lastTime = 0;
+let rafId = null;
+let dropCounter = 0;
+const dropInterval = 500;
+
+function startGameLoop(){
+  cancelAnimationFrame(rafId);
+  lastTime = 0;
+  dropCounter = 0;
+  rafId = requestAnimationFrame(update);
+}
+
+function update(time = 0){
+  if (!gameStarted) return; // guard
+  const delta = time - lastTime;
+  lastTime = time;
+  dropCounter += delta;
+  if (dropCounter > dropInterval){
+    game.tick();
+    dropCounter = 0;
+  }
+
+  ctx.clearRect(0,0,canvas.width,canvas.height);
+  drawMatrix(game.arena, {x:0,y:0});
+  if (game.active) drawMatrix(game.active.matrix, game.active.pos);
+
+  if (game.gameOver){
+    handleGameOver();
+    return;
+  }
+  rafId = requestAnimationFrame(update);
+}
+
+function drawMatrix(matrix, offset){
+  const cell = 24;
+  matrix.forEach((row,y)=>{
+    row.forEach((v,x)=>{
+      if(!v) return;
+      ctx.fillStyle = v;
+      ctx.fillRect((x+offset.x)*cell, (y+offset.y)*cell, cell-1, cell-1);
+      ctx.drawImage(ghostImg, (x+offset.x)*cell, (y+offset.y)*cell, cell, cell);
+    });
+  });
+}
+
+function handleGameOver(){
+  cancelAnimationFrame(rafId);
+  gameStarted = false;
+  showOverlay('Play again');
+}
+
+function resetGame(){
+  game.reset();
+}

--- a/src/input.js
+++ b/src/input.js
@@ -14,7 +14,7 @@ export function attachInput(game){
     window.dispatchEvent(ev)
   }
 
-  document.querySelectorAll('.controls .ctrl').forEach(btn => {
+  document.querySelectorAll('.controls button').forEach(btn => {
     btn.addEventListener('click', () => {
       const key = btn.getAttribute('data-key')
       triggerKey(key)

--- a/src/tetris.js
+++ b/src/tetris.js
@@ -27,6 +27,7 @@ export class Game{
     this.cols=cols; this.rows=rows
     this.arena = [...Array(rows)].map(()=>Array(cols).fill(0))
     this.active = null
+    this.gameOver = false
     this.spawn()
   }
   randPiece(){
@@ -66,8 +67,7 @@ export class Game{
   spawn(){
     this.active = this.randPiece()
     if(this.collide(this.active.matrix, this.active.pos)){
-      alert("You lost!")
-      this.arena.forEach(r=>r.fill(0))
+      this.gameOver = true
     }
   }
   rotate(dir){
@@ -104,4 +104,10 @@ export class Game{
     this.softDrop()
   }
   tick(){ this.softDrop() }
+
+  reset(){
+    this.arena.forEach(r=>r.fill(0))
+    this.gameOver = false
+    this.spawn()
+  }
 }

--- a/styles.css
+++ b/styles.css
@@ -1,26 +1,35 @@
+:root{
+  --bg-0: #0d0b1f;
+  --bg-1: #161238;
+  --ghost-ink: #4b3f96;
+  --tile-glow: #b9a8ff;
+  --accent: #a68cff;
+  --accent-2: #ffd9fb;
+  --text: #f7f4ff;
+  --muted: #cfc7ff;
+  --danger: #ff5c8a;
+}
+
 html, body {
   height: 100%;
   margin: 0;
   padding: 0;
 }
 
-body {
-  background: #121212;
-  color: #fff;
-  font-family: 'Roboto', sans-serif;
+/* App background */
+body{
+  background:
+    radial-gradient(1200px 1200px at 80% -20%, #2a215d 0%, transparent 60%),
+    radial-gradient(1000px 1000px at -10% 100%, #2b154c 0%, transparent 60%),
+    linear-gradient(180deg, var(--bg-0), var(--bg-1));
+  color: var(--text);
+  font-family: ui-rounded, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Color Emoji";
   display: flex;
   flex-direction: column;
   align-items: center;
 }
 
-h1 {
-  margin: 20px 0;
-  font-size: 2rem;
-  letter-spacing: 1px;
-  font-weight: 600;
-}
-
-#game {
+#board {
   background: #1e1e1e;
   border: 2px solid #333;
   box-shadow: 0 0 20px rgba(0,0,0,0.6);
@@ -29,39 +38,61 @@ h1 {
   image-rendering: pixelated;
 }
 
-.controls {
-  display: flex;
-  justify-content: center;
-  gap: 16px;
-  margin-bottom: 30px;
+/* Board cells: cute ghost tile pattern */
+.cell{
+  position: relative;
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,0.06);
+  background:
+    url("assets/ghost.svg") center/85% no-repeat,
+    radial-gradient(180% 140% at 0% 0%, rgba(255,255,255,0.08), rgba(255,255,255,0.03));
+  border-radius: 6px;
+  transition: transform 60ms ease;
+}
+.cell.filled{
+  /* slight glow for active tiles */
+  filter: drop-shadow(0 0 6px var(--tile-glow));
 }
 
-.controls .ctrl {
-  background: linear-gradient(145deg, #2d2d2d, #1a1a1a);
-  border: none;
+/* Controls */
+.controls{
+  display:flex; gap:.75rem; justify-content:center; align-items:center; padding:12px 0; margin-bottom:30px;
+}
+.btn{
+  font: inherit;
+  border: 1px solid rgba(255,255,255,0.24);
+  background: rgba(255,255,255,0.06);
+  color: var(--text);
+  padding: .75rem 1rem;
   border-radius: 12px;
-  padding: 14px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
   cursor: pointer;
-  box-shadow: 0 4px 8px rgba(0,0,0,0.4);
-  transition: all 0.2s ease;
+  backdrop-filter: blur(6px);
+  transition: transform 120ms ease, background 120ms ease;
 }
+.btn:active{ transform: translateY(1px) scale(0.98); }
+.btn.primary{ background: linear-gradient(180deg, var(--accent), #7f6bff); border-color: transparent; color:#0d0630; font-weight:700; }
+.btn.ghost{ background: rgba(255,255,255,0.08); }
 
-.controls .ctrl:hover {
-  background: linear-gradient(145deg, #3a3a3a, #222);
-  transform: translateY(-2px);
-  box-shadow: 0 6px 14px rgba(0,0,0,0.5);
+/* Overlay */
+.overlay{
+  position: fixed; inset: 0; display: grid; place-items: center;
+  background: linear-gradient(180deg, rgba(5,3,15,0.65), rgba(10,5,25,0.85));
+  opacity: 0; pointer-events: none; transition: opacity 200ms ease;
+  z-index: 999;
 }
+.overlay.visible{ opacity: 1; pointer-events: auto; }
+.overlay-card{
+  width: min(92vw, 420px);
+  background: rgba(255,255,255,0.06);
+  border: 1px solid rgba(255,255,255,0.18);
+  border-radius: 20px; padding: 28px; text-align: center;
+  backdrop-filter: blur(10px);
+  box-shadow: 0 10px 40px rgba(0,0,0,0.4);
+}
+.overlay-card h1{ margin: 10px 0 4px; letter-spacing: .5px; }
+.overlay-card p{ color: var(--muted); margin: 0 0 16px; }
+.ghost-hero{ width: 92px; height: 92px; display:block; margin:0 auto 8px; }
 
-.controls .ctrl:active {
-  transform: translateY(0);
-  box-shadow: 0 2px 6px rgba(0,0,0,0.4);
-}
+/* Optional: sidebar headings */
+.sidebar h2{ color: var(--accent-2); }
 
-.controls svg {
-  width: 28px;
-  height: 28px;
-  fill: #00ffc3;
-}
+.credit{ color: var(--muted); text-align:center; font-size:0.8rem; margin-bottom:1rem; }


### PR DESCRIPTION
## Summary
- Add translucent start and game-over overlay featuring a happy ghost and primary Start button
- Apply ghostly gradient theme and modern button styles across the app
- Gate the game loop behind a Start button and reset on game over with optional replay

## Testing
- `npm test` *(fails: Missing script "test"; no tests defined)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bbb3e1a5188330b64fa85729ba88c0