### PR TITLE
Fix mobile controls layout and start screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,6 @@
 
       <div id="controls" class="controls" role="group" aria-label="Game controls">
         <button id="btn-left" class="btn ghost" data-key="ArrowLeft" aria-label="Move left">
- codex/add-ghost-theme-and-start-button
           <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="currentColor" d="M15 18l-6-6 6-6v12z"/></svg>
         </button>
         <button id="btn-rotate" class="btn ghost" data-key="ArrowUp" aria-label="Rotate">
@@ -41,22 +40,6 @@
             <path fill="currentColor" d="M12 21l-8-8h16l-8 8z"/>
             <path stroke="currentColor" stroke-width="2" stroke-linecap="round" d="M12 3v10"/>
           </svg>
-
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M15 18l-6-6 6-6v12z"/></svg>
-        </button>
-        <button id="btn-rotate" class="btn ghost" data-key="ArrowUp" aria-label="Rotate">
-          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" viewBox="0 0 24 24">
-            <path d="M12 6V3L8 7l4 4V8c2.76 0 5 2.24 5 5a5 5 0 0 1-9.9 1h-2.02A7 7 0 0 0 12 20a7 7 0 0 0 0-14z"/>
-          </svg>
-        </button>
-        <button id="btn-right" class="btn ghost" data-key="ArrowRight" aria-label="Move right">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M9 6l6 6-6 6V6z"/></svg>
-        </button>
-        <button id="btn-soft" class="btn ghost" data-key="ArrowDown" aria-label="Soft drop">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M7 10l5 5 5-5H7z"/></svg>
-        </button>
-        <button id="btn-hard" class="btn ghost" data-key=" " aria-label="Hard drop">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 21l-8-8h16l-8 8zM12 3v10"/></svg>
         </button>
       </div>
     </div>

--- a/styles.css
+++ b/styles.css
@@ -29,6 +29,12 @@ body{
   align-items: center;
 }
 
+#game{
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
 #board {
   background: #1e1e1e;
   border: 2px solid #333;
@@ -55,7 +61,15 @@ body{
 
 /* Controls */
 .controls{
-  display:flex; gap:.75rem; justify-content:center; align-items:center; padding:12px 0; margin-bottom:30px;
+  display:flex;
+  flex-wrap: wrap;
+  gap:.75rem;
+  justify-content:center;
+  align-items:center;
+  padding:12px 0;
+  margin-bottom:30px;
+  width:100%;
+  max-width:320px;
 }
 .btn{
   font: inherit;


### PR DESCRIPTION
## Summary
- remove duplicated control buttons and stray text in index.html
- center game content and allow control buttons to wrap on small screens

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc1d8026fc8330ba3c0858238aab28