### PR TITLE
Guard ghost image drawing to prevent gravity lockup

### DIFF
--- a/script.js
+++ b/script.js
@@ -80,7 +80,9 @@ function drawMatrix(matrix, offset){
       if(!v) return;
       ctx.fillStyle = v;
       ctx.fillRect((x+offset.x)*cell, (y+offset.y)*cell, cell-1, cell-1);
-      ctx.drawImage(ghostImg, (x+offset.x)*cell, (y+offset.y)*cell, cell, cell);
+      if (ghostImg.complete) {
+        ctx.drawImage(ghostImg, (x+offset.x)*cell, (y+offset.y)*cell, cell, cell);
+      }
     });
   });
 }


### PR DESCRIPTION
## Summary
- Avoid drawing ghost sprite before it finishes loading to keep game loop running

## Testing
- `npm run build`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bc2fe2c32c83309f954a9ebf2d41f5