### PR TITLE
fix: load ghost image without bundler

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,6 +1,5 @@
 import { Game } from './src/tetris.js';
 import { attachInput } from './src/input.js';
-import ghostSrc from './assets/ghost.svg';
 
 const canvas = document.getElementById('board');
 const ctx = canvas.getContext('2d');
@@ -8,7 +7,7 @@ const game = new Game(10, 20);
 attachInput(game);
 
 const ghostImg = new Image();
-ghostImg.src = ghostSrc;
+ghostImg.src = new URL('./assets/ghost.svg', import.meta.url).href;
 
 // --- Overlay wiring ---
 let gameStarted = true;


### PR DESCRIPTION
## Summary
- load ghost image via URL so the game runs without a bundler

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bc4d9196c08330a3d69ce5c4a6752e