### PR TITLE
Add testing box and document layout change

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@
 ## Controls
 Use the on-screen buttons to move left/right, rotate, soft drop, or hard drop. No keyboard is required.
 
+## Testing box
+A small blue box is fixed to the top-right corner of the page to help verify layout changes. Leave this element in place unless explicitly removing it for testing.
+
 ## Auto-merge (Option A)
 PRs targeting `main` auto-merge after checks pass when:
 - They have the `automerge` label, or

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="styles.css">
   </head>
   <body>
+    <div id="testing-box"></div>
     <!-- Start / Game Over Overlay -->
     <div id="startScreen" class="overlay visible">
       <div class="overlay-card">

--- a/styles.css
+++ b/styles.css
@@ -110,3 +110,12 @@ body{
 .sidebar h2{ color: var(--accent-2); }
 
 .credit{ color: var(--muted); text-align:center; font-size:0.8rem; margin-bottom:1rem; }
+
+#testing-box{
+  position: fixed;
+  top: 10px;
+  right: 10px;
+  width: 40px;
+  height: 40px;
+  background: blue;
+}


### PR DESCRIPTION
## Summary
- Document testing box in README so future changes preserve it
- Add small blue testing box at top-right of page for layout verification

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bc6278bea483309fbe10c709634e5e