### PR TITLE
Auto-approve PRs for seamless deployment

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -37,6 +37,17 @@ jobs:
     if: needs.gate.outputs.run == 'true'
     runs-on: ubuntu-latest
     steps:
+      - name: Approve PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            await github.rest.pulls.createReview({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              event: 'APPROVE'
+            });
       - name: Enable auto-merge (squash)
         uses: actions/github-script@v7
         with:


### PR DESCRIPTION
## Summary
- automatically approve bot PRs before enabling auto-merge

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc6723fd888330b77e273006db3d0a