### PR TITLE
fix: prevent iOS Safari zoom

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
     <title>Ghostris</title>
     <link rel="stylesheet" href="styles.css">
   </head>

--- a/script.js
+++ b/script.js
@@ -250,3 +250,13 @@ const colors = [
   '#ffe138',
   '#3877ff',
 ];
+
+// Fallback to prevent iOS Safari double-tap zoom
+let lastTouchEnd = 0;
+document.addEventListener('touchend', (event) => {
+  const now = Date.now();
+  if (now - lastTouchEnd <= 300) {
+    event.preventDefault();
+  }
+  lastTouchEnd = now;
+}, false);

--- a/styles.css
+++ b/styles.css
@@ -86,6 +86,14 @@ body{
 .btn.primary{ background: linear-gradient(180deg, var(--accent), #7f6bff); border-color: transparent; color:#0d0630; font-weight:700; }
 .btn.ghost{ background: rgba(255,255,255,0.08); }
 
+button,
+.btn{
+  touch-action: manipulation;
+  font-size: 16px;
+  min-height: 48px;
+  min-width: 48px;
+}
+
 /* Overlay */
 .overlay{
   position: fixed; inset: 0; display: grid; place-items: center;


### PR DESCRIPTION
## Summary
- prevent Safari zoom with viewport meta tag
- enforce minimum button size and touch handling in CSS
- add JS fallback to block double-tap zoom

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bec9b925508330a482a5aa8a58e379